### PR TITLE
Add options to inject keychain access groups

### DIFF
--- a/bin/applesign.js
+++ b/bin/applesign.js
@@ -21,7 +21,8 @@ const conf = require('minimist')(process.argv.slice(2), {
     'S', 'self-signed-provision',
     'c', 'clone-entitlements',
     'u', 'unsigned-provision',
-    'V', 'dont-verify'
+    'V', 'dont-verify',
+    'B', 'bundleid-access-group'
   ]
 });
 
@@ -48,7 +49,9 @@ const options = {
   forceFamily: conf['force-family'] || conf.f,
   single: conf.single || conf.s,
   dontVerify: conf['dont-verify'] || conf.V,
-  selfSignedProvision: conf.S || conf['self-signed-provision']
+  selfSignedProvision: conf.S || conf['self-signed-provision'],
+  customKeychainGroup: conf.K || conf['add-access-group'],
+  bundleIdKeychainGroup: conf.B || conf['bundleid-access-group']
 };
 
 colors.setTheme({
@@ -81,6 +84,7 @@ if (conf.identities || conf.L) {
   -7, --use-7zip                Use 7zip instead of unzip
       --use-openssl             Use OpenSSL cms instead of Apple's security tool
   -b, --bundleid [BUNDLEID]     Change the bundleid when repackaging
+  -B, --bundleid-access-group   Add $(TeamIdentifier).bundleid to keychain-access-groups
   -c, --clone-entitlements      Clone the entitlements from the provisioning to the bin
   -e, --entitlements [ENTITL]   Specify entitlements file (EXPERIMENTAL)
   -E, --entry-entitlement       Use generic entitlement (EXPERIMENTAL)
@@ -88,6 +92,7 @@ if (conf.identities || conf.L) {
   -i, --identity [1C4D1A..]     Specify hash-id of the identity to use
   -I, --insert [frida.dylib]    Insert a dynamic library to the main executable
   -k, --keychain [KEYCHAIN]     Specify alternative keychain file
+  -K, --add-access-group [NAME] Add $(TeamIdentifier).NAME to keychain-access-groups
   -l, --lipo [arm64|armv7]      Lipo -thin all bins inside the IPA for the given architecture
   -L, --identities              List local codesign identities
   -m, --mobileprovision [FILE]  Specify the mobileprovision file to use

--- a/index.js
+++ b/index.js
@@ -38,7 +38,9 @@ module.exports = class Applesign {
       verifyTwice: opt.verifyTwice || false,
       unfairPlay: opt.unfairPlay || false,
       selfSignedProvision: opt.selfSignedProvision || false,
-      dontVerify: opt.dontVerify || false
+      dontVerify: opt.dontVerify || false,
+      bundleIdKeychainGroup: opt.bundleIdKeychainGroup || false,
+      customKeychainGroup: opt.customKeychainGroup || undefined
     };
   }
 

--- a/session.js
+++ b/session.js
@@ -354,6 +354,30 @@ module.exports = class ApplesignSession {
         changed = true;
       }
     }
+    const additionalKeychainGroups = [];
+    if (typeof this.config.customKeychainGroup === 'string') {
+      additionalKeychainGroups.push(this.config.customKeychainGroup);
+    }
+    if (this.config.bundleIdKeychainGroup) {
+      if (typeof this.config.bundleid === 'string') {
+        additionalKeychainGroups.push(this.config.bundleid);
+      } else {
+        const infoPlist = path.join(this.config.appdir, 'Info.plist');
+        const plistData = plist.readFileSync(infoPlist);
+        const bundleid = plistData['CFBundleIdentifier'];
+        additionalKeychainGroups.push(bundleid);
+      }
+    }
+    if (additionalKeychainGroups.length > 0) {
+      const newGroups = additionalKeychainGroups.map(group => `${teamId}.${group}`);
+      const groups = entMacho['keychain-access-groups'];
+      if (typeof groups === 'undefined') {
+        entMacho['keychain-access-groups'] = newGroups;
+      } else {
+        groups.push(...newGroups);
+      }
+      changed = true;
+    }
     if (changed || this.config.entry) {
       const newEntitlementsFile = file + '.entitlements';
       let newEntitlements = (appId && teamId && this.config.entry)


### PR DESCRIPTION
-K [NAME] to add a custom group name, this will be automatically prefixed with team identifier
-B to add a group named after the bundle identifier (the one from Info.plist or the one passed in -b),
also this one will be prefixed with team identifier

These are injected also when cloning entitlements from provisioning profile.