### PR TITLE
 Removed "..." references to avoid "Unexpected token" errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Usage
 
 List local codesign identities:
 
-	$ bin/applesign -I
+	$ bin/applesign -L
 
 Resign an IPA with a specific identity:
 

--- a/depsolver.js
+++ b/depsolver.js
@@ -193,7 +193,7 @@ module.exports = function depSolver (executable, libs, parallel, cb) {
              * sign those anyways, just ensure to
              * sign them before the app executable
              */
-            finalLibs.unshift(...orphaned);
+            finalLibs.unshift(orphaned);
           }
           cb(null, finalLibs);
         }

--- a/session.js
+++ b/session.js
@@ -437,7 +437,7 @@ module.exports = class ApplesignSession {
       if (typeof groups === 'undefined') {
         entMacho['keychain-access-groups'] = newGroups;
       } else {
-        groups.push(...newGroups);
+        groups.push(newGroups);
       }
       changed = true;
     }


### PR DESCRIPTION
Is it right to remove these "..." references, at least for macOS?

This PR also fixes a typo in the documentation.