### PR TITLE
Avoid renaming app groups if -c and -m are passed

### DIFF
--- a/session.js
+++ b/session.js
@@ -472,7 +472,8 @@ module.exports = class ApplesignSession {
           ? fs.readFileSync(this.config.entitlement).toString()
           : plistBuild(entMacho).toString();
       const ent = plist.parse(newEntitlements.trim());
-      if (ent['com.apple.security.application-groups']) {
+      const shouldRenameGroups = !this.config.mobileprovision && !this.config.cloneEntitlements;
+      if (shouldRenameGroups && ent['com.apple.security.application-groups']) {
         const ids = appId.split('.');
         ids.shift();
         const id = ids.join('.');


### PR DESCRIPTION
Otherwise it will result in a failure during installation for invalid entitlements - because the renamed groups don't belong to the provisioning profile we're cloning entitlements from.