### PR TITLE
override the withGetTaskAllow from the config

### DIFF
--- a/index.js
+++ b/index.js
@@ -299,9 +299,9 @@ class Applesign {
         delete entMacho['com.apple.developer.associated-domains'];
         delete entMacho['com.apple.developer.team-identifier'];
       }
-    }    
+    }
 
-    if( typeof this.config.withGetTaskAllow != 'undefined' ) {
+    if (typeof this.config.withGetTaskAllow !== 'undefined') {
       this.emit('message', 'get-task-allow set to ' + this.config.withGetTaskAllow);
       entMacho['get-task-allow'] = this.config.withGetTaskAllow;
       changed = true;

--- a/index.js
+++ b/index.js
@@ -299,14 +299,14 @@ class Applesign {
         delete entMacho['com.apple.developer.associated-domains'];
         delete entMacho['com.apple.developer.team-identifier'];
       }
+    }    
+
+    if( typeof this.config.withGetTaskAllow != 'undefined' ) {
+      this.emit('message', 'get-task-allow set to ' + this.config.withGetTaskAllow);
+      entMacho['get-task-allow'] = this.config.withGetTaskAllow;
+      changed = true;
     }
-    if (this.config.withGetTaskAllow) {
-      if (entMacho['get-task-allow'] !== true) {
-        this.emit('message', 'get-task-allow set to true');
-        entMacho['get-task-allow'] = true;
-        changed = true;
-      }
-    }
+
     const additionalKeychainGroups = [];
     if (typeof this.config.customKeychainGroup === 'string') {
       additionalKeychainGroups.push(this.config.customKeychainGroup);


### PR DESCRIPTION
The following condition never allowed the block to execute when we pass false as an argument.

> if (this.config.withGetTaskAllow) {