### PR TITLE
Resurrect the old -w behavior via -x to keep XCTests

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,8 +85,8 @@ class Applesign {
       const tasks = [];
       if (this.config.withoutWatchapp) {
         tasks.push(this.removeWatchApp());
-        tasks.push(this.removePlugins());
-      } else if (this.config.xctestsOnly) {
+      }
+      if (this.config.withoutPlugins) {
         tasks.push(this.removePlugins());
       }
       if (this.config.withoutXCTests) {
@@ -184,26 +184,23 @@ class Applesign {
 
   async removePlugins () {
     fchk(arguments, []);
-    const keepTests = this.config.xctestsOnly;
     const plugdir = path.join(this.config.appdir, 'PlugIns');
     let tests = [];
-    if (keepTests) {
-      if (fs.existsSync(plugdir)) {
-        try {
-          tests = fs.readdirSync(plugdir).filter((x) => {
-            return x.indexOf('.xctest') !== -1;
-          });
-          if (tests.length > 0) {
-            this.emit('message', 'Don\'t strip out the XCTest plugins');
-          }
-          for (let t of tests) {
-            const oldName = path.join(plugdir, t);
-            const newName = path.join(this.config.appdir, '__' + t);
-            fs.renameSync(oldName, newName);
-          }
-        } catch (err) {
-          console.error(err);
+    if (fs.existsSync(plugdir)) {
+      try {
+        tests = fs.readdirSync(plugdir).filter((x) => {
+          return x.indexOf('.xctest') !== -1;
+        });
+        if (tests.length > 0) {
+          this.emit('message', 'Don\'t strip out the XCTest plugins');
         }
+        for (let t of tests) {
+          const oldName = path.join(plugdir, t);
+          const newName = path.join(this.config.appdir, '__' + t);
+          fs.renameSync(oldName, newName);
+        }
+      } catch (err) {
+        console.error(err);
       }
     }
     this.emit('message', 'Stripping out the PlugIns at ' + plugdir);

--- a/index.js
+++ b/index.js
@@ -86,6 +86,8 @@ class Applesign {
       if (this.config.withoutWatchapp) {
         tasks.push(this.removeWatchApp());
         tasks.push(this.removePlugins());
+      } else if (this.config.xctestsOnly) {
+        tasks.push(this.removePlugins());
       }
       if (this.config.withoutXCTests) {
         tasks.push(this.removeXCTests())
@@ -182,9 +184,42 @@ class Applesign {
 
   async removePlugins () {
     fchk(arguments, []);
+    const keepTests = this.config.xctestsOnly;
     const plugdir = path.join(this.config.appdir, 'PlugIns');
+    let tests = [];
+    if (keepTests) {
+      if (fs.existsSync(plugdir)) {
+        try {
+          tests = fs.readdirSync(plugdir).filter((x) => {
+            return x.indexOf('.xctest') !== -1;
+          });
+          if (tests.length > 0) {
+            this.emit('message', 'Don\'t strip out the XCTest plugins');
+          }
+          for (let t of tests) {
+            const oldName = path.join(plugdir, t);
+            const newName = path.join(this.config.appdir, '__' + t);
+            fs.renameSync(oldName, newName);
+          }
+        } catch (err) {
+          console.error(err);
+        }
+      }
+    }
     this.emit('message', 'Stripping out the PlugIns at ' + plugdir);
     await tools.asyncRimraf(plugdir);
+    if (tests.length > 0) {
+      try {
+        fs.mkdirSync(plugdir);
+        for (let t of tests) {
+          const oldName = path.join(this.config.appdir, '__' + t);
+          const newName = path.join(plugdir, t);
+          fs.renameSync(oldName, newName);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    }
   }
 
   findProvisioningsSync () {

--- a/lib/config.js
+++ b/lib/config.js
@@ -18,8 +18,8 @@ const shortHelpMessage = `Usage:
   -m, --mobileprovision [FILE]  Specify the mobileprovision file to use
   -o, --output [APP.IPA]        Path to the output IPA filename
   -O, --osversion 9.0           Force specific OSVersion if any in Info.plist
+  -p, --without-plugins         Remove plugins (excluding XCTests) from the resigned IPA
   -w, --without-watchapp        Remove the WatchApp from the IPA before resigning
-  -W, --without-plugins         Remove plugins (excluding XCTests) from the resigned IPA
   -x, --without-xctests         Remove the XCTests from the resigned IPA
 
 Example:
@@ -38,13 +38,15 @@ const helpMessage = `Usage:
   -l, --lipo [arm64|armv7]      Lipo -thin all bins inside the IPA for the given architecture
   -n, --noclean                 keep temporary files when signing error happens
   -o, --output [APP.IPA]        Path to the output IPA filename
-  -p, --parallel                Run layered signing dependencies in parallel (EXPERIMENTAL)
+  -P, --parallel                Run layered signing dependencies in parallel (EXPERIMENTAL)
   -r, --replace                 Replace the input IPA file with the resigned one
   -u, --unfair                  Resign encrypted applications
-  -w, --without-watchapp        Remove the WatchApp from the IPA before resigning
-  -W, --without-plugins         Remove plugins (excluding XCTests) from the resigned IPA
-  -x, --without-xctests         Remove the XCTests from the resigned IPA
   -z, --ignore-zip-errors       Ignore unzip/7z uncompressing errors
+
+  Stripping:
+  -p, --without-plugins         Remove plugins (excluding XCTests) from the resigned IPA
+  -w, --without-watchapp        Remove the WatchApp from the IPA before resigning
+  -x, --without-xctests         Remove the XCTests from the resigned IPA
 
   Signing:
       --use-openssl             Use OpenSSL cms instead of Apple's security tool
@@ -158,8 +160,8 @@ const fromOptions = function (opt) {
     useOpenSSL: opt.useOpenSSL === true,
     verify: opt.verify || false,
     verifyTwice: opt.verifyTwice || false,
-    withoutWatchapp: opt.withoutWatchapp || false,
     withoutPlugins: opt.withoutPlugins || false,
+    withoutWatchapp: opt.withoutWatchapp || false,
     withoutXCTests: opt.withoutXCTests || false
   };
 };
@@ -189,7 +191,8 @@ function parse (argv) {
       'L', 'identities',
       'M', 'massage-entitlements',
       'n', 'noclean',
-      'p', 'parallel',
+      'p', 'without-plugins',
+      'P', 'parallel',
       'r', 'replace',
       'S', 'self-signed-provision',
       's', 'single',
@@ -199,7 +202,6 @@ function parse (argv) {
       'v', 'verify',
       'V', 'verify-twice',
       'w', 'without-watchapp',
-      'W', 'without-plugins',
       'x', 'without-xctests',
       'z', 'ignore-zip-errors'
     ]
@@ -232,7 +234,7 @@ function compile (conf) {
     noEntitlementsFile: conf.C || conf['no-entitlements-file'] || conf.noEntitlementsFile,
     osversion: conf.osversion || conf.O,
     outfile: (conf.output || conf.o) ? path.resolve(conf.output || conf.o): '',
-    parallel: conf.parallel || conf.p,
+    parallel: conf.parallel || conf.P,
     replaceipa: conf.replace || conf.r,
     selfSignedProvision: conf.S || conf['self-signed-provision'],
     single: conf.single || conf.s,
@@ -242,7 +244,7 @@ function compile (conf) {
     verify: conf.v || conf.V || conf.verify || conf['verify-twice'],
     verifyTwice: conf.V || conf['verify-twice'],
     withoutWatchapp: !!conf['without-watchapp'] || !!conf.w,
-    withoutPlugins: !!conf['without-plugins'] || !!conf.W,
+    withoutPlugins: !!conf['without-plugins'] || !!conf.p,
     withoutXCTests: !!conf['without-xctests'] || !!conf.x
   };
   return options;

--- a/lib/config.js
+++ b/lib/config.js
@@ -20,6 +20,7 @@ const shortHelpMessage = `Usage:
   -O, --osversion 9.0           Force specific OSVersion if any in Info.plist
   -w, --without-watchapp        Remove the WatchApp from the IPA before resigning
   -W, --without-xctests         Remove the XCTests from the resigned IPA
+  -x, --xctests-only            Remove all plugins except XCTests from the resigned IPA
 
 Example:
 
@@ -42,6 +43,7 @@ const helpMessage = `Usage:
   -u, --unfair                  Resign encrypted applications
   -w, --without-watchapp        Remove the WatchApp from the IPA before resigning
   -W, --without-xctests         Remove the XCTests from the resigned IPA
+  -x, --xctests-only            Remove all plugins except XCTests from the resigned IPA
   -z, --ignore-zip-errors       Ignore unzip/7z uncompressing errors
 
   Signing:
@@ -157,7 +159,8 @@ const fromOptions = function (opt) {
     verify: opt.verify || false,
     verifyTwice: opt.verifyTwice || false,
     withoutWatchapp: opt.withoutWatchapp || false,
-    withoutXCTests: opt.withoutXCTests || false
+    withoutXCTests: opt.withoutXCTests || false,
+    xctestsOnly: opt.xctestsOnly || false
   };
 };
 
@@ -197,6 +200,7 @@ function parse (argv) {
       'V', 'verify-twice',
       'w', 'without-watchapp',
       'W', 'without-xctests',
+      'x', 'xctests-only',
       'z', 'ignore-zip-errors'
     ]
   });
@@ -238,7 +242,8 @@ function compile (conf) {
     verify: conf.v || conf.V || conf.verify || conf['verify-twice'],
     verifyTwice: conf.V || conf['verify-twice'],
     withoutWatchapp: !!conf['without-watchapp'] || !!conf.w,
-    withoutXCTests: !!conf['without-xctests'] || !!conf.W
+    withoutXCTests: !!conf['without-xctests'] || !!conf.W,
+    xctestsOnly: !!conf['xctests-only'] || !!conf.x
   };
   return options;
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -19,8 +19,8 @@ const shortHelpMessage = `Usage:
   -o, --output [APP.IPA]        Path to the output IPA filename
   -O, --osversion 9.0           Force specific OSVersion if any in Info.plist
   -w, --without-watchapp        Remove the WatchApp from the IPA before resigning
-  -W, --without-xctests         Remove the XCTests from the resigned IPA
-  -x, --xctests-only            Remove all plugins except XCTests from the resigned IPA
+  -W, --without-plugins         Remove plugins (excluding XCTests) from the resigned IPA
+  -x, --without-xctests         Remove the XCTests from the resigned IPA
 
 Example:
 
@@ -42,8 +42,8 @@ const helpMessage = `Usage:
   -r, --replace                 Replace the input IPA file with the resigned one
   -u, --unfair                  Resign encrypted applications
   -w, --without-watchapp        Remove the WatchApp from the IPA before resigning
-  -W, --without-xctests         Remove the XCTests from the resigned IPA
-  -x, --xctests-only            Remove all plugins except XCTests from the resigned IPA
+  -W, --without-plugins         Remove plugins (excluding XCTests) from the resigned IPA
+  -x, --without-xctests         Remove the XCTests from the resigned IPA
   -z, --ignore-zip-errors       Ignore unzip/7z uncompressing errors
 
   Signing:
@@ -159,8 +159,8 @@ const fromOptions = function (opt) {
     verify: opt.verify || false,
     verifyTwice: opt.verifyTwice || false,
     withoutWatchapp: opt.withoutWatchapp || false,
-    withoutXCTests: opt.withoutXCTests || false,
-    xctestsOnly: opt.xctestsOnly || false
+    withoutPlugins: opt.withoutPlugins || false,
+    withoutXCTests: opt.withoutXCTests || false
   };
 };
 
@@ -199,8 +199,8 @@ function parse (argv) {
       'v', 'verify',
       'V', 'verify-twice',
       'w', 'without-watchapp',
-      'W', 'without-xctests',
-      'x', 'xctests-only',
+      'W', 'without-plugins',
+      'x', 'without-xctests',
       'z', 'ignore-zip-errors'
     ]
   });
@@ -242,8 +242,8 @@ function compile (conf) {
     verify: conf.v || conf.V || conf.verify || conf['verify-twice'],
     verifyTwice: conf.V || conf['verify-twice'],
     withoutWatchapp: !!conf['without-watchapp'] || !!conf.w,
-    withoutXCTests: !!conf['without-xctests'] || !!conf.W,
-    xctestsOnly: !!conf['xctests-only'] || !!conf.x
+    withoutPlugins: !!conf['without-plugins'] || !!conf.W,
+    withoutXCTests: !!conf['without-xctests'] || !!conf.x
   };
   return options;
 }


### PR DESCRIPTION
This change adds back the code that preserved XCTest files when the Plugins directory is deleted, but controls it via the option `-x`: when specified alone, all plugins except XCTest files are removed; when specified with -w it will preserve the XCTest files instead of removing the entire Plugins directory.

I didn't look through all the commit history for this part of the code, so there may be better (more recent) code that would be preferable to restore.