### PR TITLE
Add -j to specify a JSON with custom signing options

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -144,7 +144,7 @@ const fromOptions = function (opt) {
   return {
     all: opt.all || false,
     allowHttp: opt.allowHttp || false,
-    json: JSON.parse(opt.json || {}),
+    json: JSON.parse(opt.json || '{}'),
     osversion: opt.osversion || undefined,
     bundleid: opt.bundleid || undefined,
     bundleIdKeychainGroup: opt.bundleIdKeychainGroup || false,

--- a/lib/config.js
+++ b/lib/config.js
@@ -52,7 +52,8 @@ const helpMessage = `Usage:
       --use-openssl             Use OpenSSL cms instead of Apple's security tool (EXPERIMENTAL)
   -a, --all                     Resign all binaries, even it unrelated to the app
   -i, --identity [1C4D1A..]     Specify hash-id of the identity to use
-  -k, --keychain [KEYCHAIN]     Specify alternative keychain file
+  -j, --json '{}'               Set the alternative JSON for signing files with custom entitlments
+  -k, --keychain [KEYCHAIN]     Specify custom keychain file
   -K, --add-access-group [NAME] Add $(TeamIdentifier).NAME to keychain-access-groups
   -L, --identities              List local codesign identities
   -m, --mobileprovision [FILE]  Specify the mobileprovision file to use
@@ -86,12 +87,29 @@ Examples:
   $ applesign -m embedded.mobileprovision target.ipa
   $ applesign -i AD71EB42BC289A2B9FD3C2D5C9F02D923495A23C target.ipa
   $ applesign -m a.mobileprovision -c --lipo arm64 -w target.ipa
+  $ applesign -m a.mobileprovision -j '{"custom":[{"filematch":"ShareExtension$","entitlements":"/tmp/foo.ent"}]}' target.ipa
 
 Installing in the device:
 
   $ ideviceinstaller -i target-resigned.ipa
   $ ios-deploy -b  target-resigned.ipa
 `;
+
+/*
+// Expected format:
+// ----------------
+
+{
+  "custom": [
+    {
+      "filematch": "ShareExtension$",
+      "entitlements": "/tmp/share.entitlements",
+      "__identity": "83498489489X",
+    }
+  ]
+}
+
+*/
 
 const fromOptions = function (opt) {
   if (typeof opt !== 'object') {
@@ -126,6 +144,7 @@ const fromOptions = function (opt) {
   return {
     all: opt.all || false,
     allowHttp: opt.allowHttp || false,
+    json: JSON.parse(opt.json || {}),
     osversion: opt.osversion || undefined,
     bundleid: opt.bundleid || undefined,
     bundleIdKeychainGroup: opt.bundleIdKeychainGroup || false,
@@ -173,6 +192,7 @@ const fromState = function (state) {
 function parse (argv) {
   return require('minimist')(argv.slice(2), {
     string: [
+      'j', 'json',
       'i', 'identity',
       'O', 'osversion',
       'R', 'run'
@@ -222,6 +242,7 @@ function compile (conf) {
     file: conf._[0] || undefined,
     forceFamily: conf['force-family'] || conf.f,
     withGetTaskAllow: !(conf['without-get-task-allow'] || conf.t),
+    json: conf.json || conf.j,
     identity: conf.identity || conf.i,
     ignoreZipErrors: conf.z || conf['ignore-zip-errors'],
     insertLibrary: conf.I || conf.insert,


### PR DESCRIPTION
This feature has been requested for a couple of years already, and the only reason for not having it was a simple interface for managing all the possible use cases. In order to move forward i just implemented -j which allows to override with an inline json string the signing options for files matching specific attributes, here's an example:

```json
{
  "custom": [
      {
      "filematch": "RegexMatchExpr$",
      "entitlements": "/tmp/custom-entitlements.plist",
      "identity": "89312489X",
      "keychain": "/tmp/custom-keychain.db"
     }
  ]
}
```

The only required key in here is `filematch` which is used by signFile to determine which files needs to use custom signing options. The entitlements, identity and keychain path fields are optional. those will override the default signing attributes when matching.

This is useful for resigning app extensions like custom keyboards, network extensions, sharing extensions, etc.. which use to have different entitlements (and in some cases different signing identities, f.ex: apple watch)

Note that in order to sign app extensions you need to pass the `-a`  flag to sign ALL the binaries, even the ones not associated with the main app executable

To sumarize in one line: 

```
$ applesign -a -m embedded.mobileprovision -c -j "`cat foo.json`" Twitter.ipa
```

PD: This is an experimental feature. json format, options and commandline flags may change in the future.
PD2: Review comments are welcome