### PR TITLE
Remove com.apple.WatchPlaceholder directory when -w is specified

### DIFF
--- a/index.js
+++ b/index.js
@@ -168,6 +168,10 @@ class Applesign {
     const watchdir = path.join(this.config.appdir, 'Watch');
     this.emit('message', 'Stripping out the WatchApp at ' + watchdir);
     await tools.asyncRimraf(watchdir);
+
+    const placeholderdir = path.join(this.config.appdir, 'com.apple.WatchPlaceholder');
+    this.emit('message', 'Stripping out the WatchApp at ' + placeholderdir);
+    await tools.asyncRimraf(placeholderdir);
   }
 
   // XXX some directory leftovers


### PR DESCRIPTION
It appears that Watch apps can be bundled into a directory called `com.apple.WatchPlaceholder`.  This change removes that directory when `-w` is specified.