### PR TITLE
Fix signing order

### DIFF
--- a/index.js
+++ b/index.js
@@ -660,7 +660,7 @@ class Applesign {
       }
       this.debugInfo('analysis', 'orphan', ls.orphanedLibraries());
       // const libraries = ls.diskLibraries ();
-      libs = libraries;
+      libs = libraries.filter(library => !(ls.appexs.includes(library))); // remove already-signed appexs
     }
     if (libs.length === 0) {
       libs.push(bpath);

--- a/lib/appdir.js
+++ b/lib/appdir.js
@@ -199,7 +199,7 @@ function _findLibraries (appdir, appbin, appexs, disklibs) {
   const libraries = [];
   const pending = [exe, ...appexs];
   while (pending.length > 0) {
-    const target = pending.pop();
+    const target = pending.shift();
     if (libraries.indexOf(target) === -1) {
       libraries.push(target);
     }


### PR DESCRIPTION
This change does two things:
* When an appex is signed, it is removed from the list of things to sign in a later step
* When creating the list of libraries, add the main executable first and then the appexs instead of the reverse