### PR TITLE
Throw errors so API use can catch them

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,7 +101,6 @@ class Applesign {
       await this.zipIPA();
     } catch (e) {
       process.exitCode = 1;
-      console.error(e);
       throw e;
     } finally {
       await this.cleanup();

--- a/index.js
+++ b/index.js
@@ -102,8 +102,10 @@ class Applesign {
     } catch (e) {
       process.exitCode = 1;
       console.error(e);
+      throw e;
+    } finally {
+      await this.cleanup();
     }
-    await this.cleanup();
     return this;
   }
 


### PR DESCRIPTION
Currently if an error is caught in `signIPA` it is not re-thrown.  As a result, if someone is using the API they will not be able to catch and respond properly to errors - it will appear that the function succeeds (outside of the error being logged).