### PR TITLE
Add option to pseudo-sign using ldid2

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -63,6 +63,7 @@ const helpMessage = `Usage:
   -S, --self-sign-provision     Self-sign mobile provisioning (EXPERIMENTAL)
   -v, --verify                  Verify all the signed files at the end
   -V, --verify-twice            Verify after signing every file and at the end
+  -Z, --pseudo-sign             Pseudo sign the binaries (EXPERIMENTAL)
 
   Info.plist
   -b, --bundleid [BUNDLEID]     Change the bundleid when repackaging
@@ -176,6 +177,7 @@ const fromOptions = function (opt) {
     outdir: undefined,
     outfile: opt.outfile,
     parallel: opt.parallel || false,
+    pseudoSign: opt.pseudoSign || false,
     replaceipa: opt.replaceipa || false,
     selfSignedProvision: opt.selfSignedProvision || false,
     unfairPlay: opt.unfairPlay || false,
@@ -228,7 +230,8 @@ function parse (argv) {
       'V', 'verify-twice',
       'w', 'without-watchapp',
       'x', 'without-xctests',
-      'z', 'ignore-zip-errors'
+      'z', 'ignore-zip-errors',
+      'Z', 'pseudo-sign'
     ]
   });
 }
@@ -262,6 +265,7 @@ function compile (conf) {
     osversion: conf.osversion || conf.O,
     outfile: (conf.output || conf.o) ? path.resolve(conf.output || conf.o) : '',
     parallel: conf.parallel || conf.P,
+    pseudoSign: conf.Z || conf['pseudo-sign'],
     replaceipa: conf.replace || conf.r,
     selfSignedProvision: conf.S || conf['self-signed-provision'],
     single: conf.single || conf.s,

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -23,7 +23,8 @@ const cmd = {
   security: '/usr/bin/security',
   unzip: '/usr/bin/unzip',
   xcodebuild: '/usr/bin/xcodebuild',
-  zip: '/usr/bin/zip'
+  zip: '/usr/bin/zip',
+  ldid2: 'ldid2'
 };
 
 async function execProgram (bin, arg, opt) {
@@ -100,6 +101,15 @@ async function codesign (identity, entitlement, keychain, file) {
   }
   args.push(file);
   return execProgram(cmd.codesign, args, null);
+}
+
+async function pseudoSign (entitlement, file) {
+  const args = [];
+  if (typeof entitlement === 'string') {
+    args.push('-S' + entitlement);
+  }
+  args.push(file);
+  return execProgram(cmd.ldid2, args, null);
 }
 
 async function verifyCodesign (file, keychain, cb) {
@@ -274,8 +284,10 @@ function asyncRimraf (dir) {
   });
 }
 
-[findInPath,
+[
+  findInPath,
   codesign,
+  pseudoSign,
   verifyCodesign,
   getEntitlementsFromMobileProvision,
   getMobileProvisionPlist,


### PR DESCRIPTION
Used `-Z` because the meaningful part of the alphabet was already taken 😅.

With this change `bin/applesign -Z` just pseudo-signs the input IPA without the need to specify a mobile provisioning profile and preserves the entitlements as they are. Potentially, it's possible to further extend this and also merge in additional entitlements.