### PR TITLE
Check tools existence lazily

### DIFF
--- a/bin/applesign.js
+++ b/bin/applesign.js
@@ -17,9 +17,9 @@ colors.setTheme({
 async function main (argv) {
   const conf = config.parse(argv);
   const options = config.compile(conf);
+  await tools.findInPath();
   const as = new Applesign(options);
   // initialize
-  await tools.findInPath();
   if (conf.identities || conf.L) {
     const ids = await as.getIdentities();
     ids.forEach((id) => {

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -13,7 +13,7 @@ const rimraf = require('rimraf');
 var use7zip = false;
 var useOpenSSL = false;
 
-const cmd = {
+const cmdSpec = {
   '7z': '/usr/local/bin/7z',
   codesign: '/usr/bin/codesign',
   insert_dylib: 'insert_dylib',
@@ -26,6 +26,8 @@ const cmd = {
   zip: '/usr/bin/zip',
   ldid2: 'ldid2'
 };
+
+const cmd = {};
 
 async function execProgram (bin, arg, opt) {
   return new Promise((resolve, reject) => {
@@ -70,18 +72,25 @@ function isDramatic (msg) {
 
 async function findInPath () {
   return new Promise((resolve, reject) => {
-    const keys = Object.keys(cmd);
+    const keys = Object.keys(cmdSpec);
     for (const key of keys) {
       try {
         cmd[key] = which.sync(key);
       } catch (err) {
-        if (isDramatic(err.toString())) {
-          return reject(new Error('Warning: tools.findInPath: ' + err));
-        }
       }
     }
     resolve();
   });
+}
+
+function getTool (tool) {
+  if (!(tool in cmd)) {
+    if (isDramatic(tool)) {
+      throw new Error(`Warning: tools.findInPath: not found: ${tool}`);
+    }
+    return null;
+  }
+  return cmd[tool];
 }
 
 async function codesign (identity, entitlement, keychain, file) {
@@ -100,7 +109,7 @@ async function codesign (identity, entitlement, keychain, file) {
     args.push('--keychain=' + keychain);
   }
   args.push(file);
-  return execProgram(cmd.codesign, args, null);
+  return execProgram(getTool('codesign'), args, null);
 }
 
 async function pseudoSign (entitlement, file) {
@@ -109,7 +118,7 @@ async function pseudoSign (entitlement, file) {
     args.push('-S' + entitlement);
   }
   args.push(file);
-  return execProgram(cmd.ldid2, args, null);
+  return execProgram(getTool('ldid2'), args, null);
 }
 
 async function verifyCodesign (file, keychain, cb) {
@@ -118,7 +127,7 @@ async function verifyCodesign (file, keychain, cb) {
     args.push('--keychain=' + keychain);
   }
   args.push(file);
-  return execProgram(cmd.codesign, args, null, cb);
+  return execProgram(getTool('codesign'), args, null, cb);
 }
 
 async function getMobileProvisionPlist (file) {
@@ -129,11 +138,11 @@ async function getMobileProvisionPlist (file) {
   if (useOpenSSL === true) {
     /* portable using openssl */
     const args = ['cms', '-in', file, '-inform', 'der', '-verify'];
-    res = await execProgram(cmd.openssl, args, null);
+    res = await execProgram(getTool('openssl'), args, null);
   } else {
     /* OSX specific using security */
     const args = ['cms', '-D', '-i', file];
-    res = await execProgram(cmd.security, args, null);
+    res = await execProgram(getTool('security'), args, null);
   }
   return plist.parse(res.stdout);
 }
@@ -153,30 +162,30 @@ async function zip (cwd, ofile, src) {
   if (use7zip) {
     const zipFile = ofile + '.zip';
     const args = ['a', zipFile, src];
-    await execProgram(cmd['7z'], args, { cwd: cwd });
+    await execProgram(getTool('7z'), args, { cwd: cwd });
     await renameAsync(zipFile, ofile);
   } else {
     const args = ['-qry', ofile, src];
-    await execProgram(cmd.zip, args, { cwd: cwd });
+    await execProgram(getTool('zip'), args, { cwd: cwd });
   }
 }
 
 async function unzip (ifile, odir) {
   if (use7zip) {
     const args = ['x', '-y', '-o' + odir, ifile];
-    return execProgram(cmd['7z'], args, null);
+    return execProgram(getTool('7z'), args, null);
   }
   if (process.env.UNZIP !== undefined) {
     cmd.unzip = process.env.UNZIP;
     delete process.env.UNZIP;
   }
   const args = ['-o', ifile, '-d', odir];
-  return execProgram(cmd.unzip, args, null);
+  return execProgram(getTool('unzip'), args, null);
 }
 
 async function xcaToIpa (ifile, odir) {
   const args = ['-exportArchive', '-exportFormat', 'ipa', '-archivePath', ifile, '-exportPath', odir];
-  return execProgram(cmd.xcodebuild, args, null);
+  return execProgram(getTool('xcodebuild'), args, null);
 }
 
 async function insertLibrary (lib, bin, out) {
@@ -205,9 +214,9 @@ async function insertLibrary (lib, bin, out) {
       error = e;
     }
   } catch (e) {
-    if (cmd.insert_dylib) {
+    if (getTool('insert_dylib') !== null) {
       const args = ['--strip-codesig', '--all-yes', lib, bin, bin];
-      const res = await execProgram(cmd.insert_dylib, args, null);
+      const res = await execProgram(getTool('insert_dylib'), args, null);
       console.error(JSON.stringify(res));
     } else {
       error = new Error('Cannot find insert_dylib or macho-mangle');
@@ -241,19 +250,19 @@ function getIdentitiesFromString (stdout) {
 }
 
 function getIdentitiesSync (bin, arg) {
-  const command = [cmd.security, 'find-identity', '-v', '-p', 'codesigning'];
+  const command = [getTool('security'), 'find-identity', '-v', '-p', 'codesigning'];
   return getIdentitiesFromString(execSync(command.join(' ')).toString());
 }
 
 async function getIdentities () {
   const args = ['find-identity', '-v', '-p', 'codesigning'];
-  const res = await execProgram(cmd.security, args, null);
+  const res = await execProgram(getTool('security'), args, null);
   return getIdentitiesFromString(res.stdout);
 }
 
 async function lipoFile (file, arch, cb) {
   const args = [file, '-thin', arch, '-output', file];
-  return execProgram(cmd.lipo, args, null, cb);
+  return execProgram(getTool('lipo'), args, null, cb);
 }
 
 function isDirectory (pathString) {


### PR DESCRIPTION
Throw on non-existent tools only when trying to use them.

Related to: https://github.com/nowsecure/node-applesign/issues/115