### PR TITLE
Retain entitlements when pseudo signing

### DIFF
--- a/index.js
+++ b/index.js
@@ -537,6 +537,9 @@ class Applesign {
     }
     let res;
     if (this.config.pseudoSign) {
+      const newEntitlementsFile = file + '.entitlements';
+      const tmpEntitlementsFile = this._pathInTmp(newEntitlementsFile);
+      const entitlements = fs.existsSync(tmpEntitlementsFile) ? tmpEntitlementsFile : null;
       res = await tools.pseudoSign(entitlements, file);
     } else {
       const keychain = getKeychain();

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -107,6 +107,8 @@ async function pseudoSign (entitlement, file) {
   const args = [];
   if (typeof entitlement === 'string') {
     args.push('-S' + entitlement);
+  } else {
+    args.push('-S');
   }
   args.push(file);
   return execProgram(cmd.ldid2, args, null);


### PR DESCRIPTION
Fix an issue in the pseudo-signing implementation for which it failed to preserve the entitlements, and also failed to sign at all when entitlements are not required. TLDR: fix a total failure, sorry.