### PR TITLE
Fix for empty entitlements and delete keychain-access-groups when not cloned

### DIFF
--- a/index.js
+++ b/index.js
@@ -371,7 +371,6 @@ class Applesign {
           'com.apple.networking.vpn.configuration',
           'com.apple.developer.associated-domains',
           'com.apple.security.application-groups',
-          'com.apple.developer.team-identifier',
           'com.apple.developer.in-app-payments',
           'com.apple.developer.siri',
           'beta-reports-active', /* our entitlements doesnt support beta */
@@ -392,7 +391,8 @@ class Applesign {
         delete entMacho['aps-environment'];
         delete entMacho['com.apple.security.application-groups'];
         delete entMacho['com.apple.developer.associated-domains'];
-        delete entMacho['com.apple.developer.team-identifier'];
+        delete entMacho['keychain-access-groups'];
+        changed = true;
       }
     }
 
@@ -507,7 +507,7 @@ class Applesign {
     const custom = customOptions(config, file);
     function getKeychain () { return (custom !== false && custom.keychain !== undefined) ? custom.keychain : config.keychain; }
     function getIdentity () { return (custom !== false && custom.identity !== undefined) ? custom.identity : config.identity; }
-    function getEntitlements () { return (custom !== false && custom.entitlements !== undefined) ? custom.entitlements : config.entitlements; }
+    function getEntitlements () { return (custom !== false && custom.entitlements !== undefined) ? custom.entitlements : config.entitlement; }
 
     fchk(arguments, ['string']);
     if (this.config.lipoArch !== undefined) {


### PR DESCRIPTION
While trying to reproduce #113 I observed the following using a free developer account:
- When using just `-m`, `-c`, and `-a`, installing the re-signed ipa would fail with complaints about `application-identifier` and `keychain-access-groups` in the logs.  Adding `-b` with the bundle ID in my mobileprovision file fixed it and I advised the original reporter to try that.
- When using the above without `-c`, installing would fail and there would be no entitlements in the app binary.  I traced that to a typo `config.entitlements` instead of `config.entitlement`, fixed in this PR.
- After that fix, the ipa would still fail to install without `-c`.  I made two changes to fix that:
  - Stopped removing the `com.apple.developer.team-identifier` since it is actually set to the one in the provisioning profile earlier in the code
  - Removed `keychain-access-groups` since they can't work with the wrong team ID anyway.