### PR TITLE
Improve error handling when used via JS APIs

### DIFF
--- a/bin/applesign.js
+++ b/bin/applesign.js
@@ -17,7 +17,6 @@ colors.setTheme({
 async function main (argv) {
   const conf = config.parse(argv);
   const options = config.compile(conf);
-  await tools.findInPath();
   const as = new Applesign(options);
   // initialize
   if (conf.identities || conf.L) {
@@ -52,6 +51,7 @@ async function main (argv) {
       const message = 'Target is now signed: ' + outfile;
       console.log(message);
     } catch (e) {
+      process.exitCode = 1;
       console.error(e);
     } finally {
       await as.cleanupTmp();

--- a/index.js
+++ b/index.js
@@ -113,11 +113,9 @@ class Applesign {
       }
       await this.signAppDirectory(appDirectory);
       await this.zipIPA();
-    } catch (e) {
-      process.exitCode = 1;
-      console.error(e);
+    } finally {
+      await this.cleanup();
     }
-    await this.cleanup();
     return this;
   }
 

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -29,6 +29,7 @@ const cmdSpec = {
 };
 
 const cmd = {};
+let cmdInited = false;
 
 async function execProgram (bin, arg, opt) {
   return new Promise((resolve, reject) => {
@@ -71,20 +72,22 @@ function isDramatic (msg) {
   return true;
 }
 
-async function findInPath () {
-  return new Promise((resolve, reject) => {
-    const keys = Object.keys(cmdSpec);
-    for (const key of keys) {
-      try {
-        cmd[key] = which.sync(key);
-      } catch (err) {
-      }
+function findInPath () {
+  if (cmdInited) {
+    return;
+  }
+  cmdInited = true;
+  const keys = Object.keys(cmdSpec);
+  for (const key of keys) {
+    try {
+      cmd[key] = which.sync(key);
+    } catch (err) {
     }
-    resolve();
-  });
+  }
 }
 
 function getTool (tool) {
+  findInPath();
   if (!(tool in cmd)) {
     if (isDramatic(tool)) {
       throw new Error(`Warning: tools.findInPath: not found: ${tool}`);
@@ -309,7 +312,6 @@ function asyncRimraf (dir) {
 }
 
 [
-  findInPath,
   codesign,
   pseudoSign,
   verifyCodesign,


### PR DESCRIPTION
- don't swallow errors in `signIPA()`
- make `findInPath()` implicit in `getTool()` and idempotent