### PR TITLE
fix: ensure apexInfo.CFBundleExecutable is truthy before use

### DIFF
--- a/lib/appdir.js
+++ b/lib/appdir.js
@@ -111,9 +111,11 @@ function _getAppExtensions (appdir) {
       const apexPlist = path.join(apexDir, 'Info.plist');
       if (fs.existsSync(apexPlist)) {
         const apexInfo = plist.readFileSync(apexPlist);
-        const apexBin = path.join(apexDir, apexInfo.CFBundleExecutable);
-        if (fs.existsSync(apexBin)) {
-          apexBins.push(apexBin);
+        if (apexInfo.CFBundleExecutable) {
+          const apexBin = path.join(apexDir, apexInfo.CFBundleExecutable);
+          if (fs.existsSync(apexBin)) {
+            apexBins.push(apexBin);
+          }
         }
       }
     }


### PR DESCRIPTION
If there is no executable for applesign to sign, a type error is thrown because `undefined` is passed to `path.join`. 

Checking to make sure `apexInfo.CFBundleExecutable` is not undefined before continuing appears to fix this