### PR TITLE
Get codesign identifier from macho

### DIFF
--- a/lib/bin.js
+++ b/lib/bin.js
@@ -9,6 +9,7 @@ const MACH0_MIN_SIZE = 1024 * 4;
 const MH_EXECUTE = 2;
 const MH_DYLIB = 6;
 const MH_BUNDLE = 8;
+const CSSLOT_CODEDIRECTORY = 0;
 
 function isMacho (filePath) {
   if (typeof filePath !== 'string') {
@@ -169,11 +170,48 @@ function entitlements (file) {
   return machoEntitlements.parseFile(file);
 }
 
+function getIdentifier (path) {
+  const data = fs.readFileSync(path);
+  const bin = parseMacho(data);
+  for (const cmd of bin.cmds) {
+    if (cmd.type === 'code_signature') {
+      return parseIdentifier(data.slice(cmd.dataoff));
+    }
+  }
+
+  function parseIdentifier (data) {
+    const count = data.readUInt32BE(8);
+    for (let i = 0; i < count; i++) {
+      const base = 8 * i;
+      const type = data.readUInt32BE(base + 12);
+      const blob = data.readUInt32BE(base + 16);
+      if (type === CSSLOT_CODEDIRECTORY) {
+        const size = data.readUInt32BE(blob + 4);
+        const directory = data.slice(blob + 8, blob + size);
+        const identOffset = directory.readUInt32BE(12);
+        const identifier = [];
+        let cursor = identOffset;
+        while (cursor < size) {
+          const charCode = data.readUInt8(blob + cursor);
+          if (charCode === 0) {
+            break;
+          }
+          identifier.push(String.fromCharCode(charCode));
+          cursor++;
+        }
+        return identifier.join('');
+      }
+    }
+    return null;
+  }
+}
+
 module.exports = {
-  entitlements: entitlements,
-  isMacho: isMacho,
-  isBitcode: isBitcode,
-  isEncrypted: isEncrypted,
-  isTruncated: isTruncated,
-  enumerateLibraries: enumerateLibraries
+  entitlements,
+  isMacho,
+  isBitcode,
+  isEncrypted,
+  isTruncated,
+  enumerateLibraries,
+  getIdentifier
 };

--- a/lib/tools.js
+++ b/lib/tools.js
@@ -9,6 +9,7 @@ const plist = require('simple-plist');
 const path = require('path');
 const which = require('which');
 const rimraf = require('rimraf');
+const bin = require('./bin');
 
 let use7zip = false;
 let useOpenSSL = false;
@@ -135,23 +136,12 @@ async function pseudoSign (entitlement, file) {
   } else {
     args.push('-S');
   }
-  const identifier = await getIdentifier(file);
-  if (identifier !== undefined) {
+  const identifier = bin.getIdentifier(file);
+  if (identifier !== null && identifier !== '') {
     args.push('-I' + identifier);
   }
   args.push(file);
   return execProgram(getTool('ldid2'), args, null);
-}
-
-async function getIdentifier (file) {
-  const res = await execProgram(getTool('codesign'), ['-dv', file], null);
-  const lines = res.stderr.split('\n');
-  for (const line of lines) {
-    const splt = line.split('Identifier=');
-    if (splt.length === 2) {
-      return splt[1];
-    }
-  }
 }
 
 async function verifyCodesign (file, keychain, cb) {


### PR DESCRIPTION
So we don't depend on `codesign` for this