### PR TITLE
chore: apply npm audit fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -594,11 +594,11 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -850,9 +850,9 @@
       "dev": true
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
@@ -1875,9 +1875,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -1978,6 +1978,19 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -3017,12 +3030,12 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -3229,9 +3242,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-10.2.5.tgz",
-      "integrity": "sha512-lXdZ7titEN8CH5YJk9C/aYRU9JeDxQ4d8rwIIDsvH3SMjLjHTukB2CFstMiB30zXs4vCrPN2WH6cDq1yHBeJAw==",
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-10.9.2.tgz",
+      "integrity": "sha512-iriPEPIkoMYUy3F6f3wwSZAU93E0Eg6cHwIR6jzzOXWSy+SD/rOODEs74cVONHKSx2obXtuUoyidVEhISrisgQ==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -3240,6 +3253,7 @@
         "@npmcli/map-workspaces",
         "@npmcli/package-json",
         "@npmcli/promise-spawn",
+        "@npmcli/redact",
         "@npmcli/run-script",
         "@sigstore/tuf",
         "abbrev",
@@ -3248,8 +3262,6 @@
         "chalk",
         "ci-info",
         "cli-columns",
-        "cli-table3",
-        "columnify",
         "fastest-levenshtein",
         "fs-minipass",
         "glob",
@@ -3285,7 +3297,6 @@
         "npm-profile",
         "npm-registry-fetch",
         "npm-user-validate",
-        "npmlog",
         "p-map",
         "pacote",
         "parse-conflict-json",
@@ -3295,7 +3306,6 @@
         "semver",
         "spdx-expression-parse",
         "ssri",
-        "strip-ansi",
         "supports-color",
         "tar",
         "text-table",
@@ -3308,76 +3318,73 @@
       "dev": true,
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^7.2.1",
-        "@npmcli/config": "^8.0.2",
-        "@npmcli/fs": "^3.1.0",
-        "@npmcli/map-workspaces": "^3.0.4",
-        "@npmcli/package-json": "^5.0.0",
-        "@npmcli/promise-spawn": "^7.0.0",
-        "@npmcli/run-script": "^7.0.2",
-        "@sigstore/tuf": "^2.2.0",
-        "abbrev": "^2.0.0",
+        "@npmcli/arborist": "^8.0.0",
+        "@npmcli/config": "^9.0.0",
+        "@npmcli/fs": "^4.0.0",
+        "@npmcli/map-workspaces": "^4.0.2",
+        "@npmcli/package-json": "^6.1.0",
+        "@npmcli/promise-spawn": "^8.0.2",
+        "@npmcli/redact": "^3.0.0",
+        "@npmcli/run-script": "^9.0.1",
+        "@sigstore/tuf": "^3.0.0",
+        "abbrev": "^3.0.0",
         "archy": "~1.0.0",
-        "cacache": "^18.0.1",
+        "cacache": "^19.0.1",
         "chalk": "^5.3.0",
-        "ci-info": "^4.0.0",
+        "ci-info": "^4.1.0",
         "cli-columns": "^4.0.0",
-        "cli-table3": "^0.6.3",
-        "columnify": "^1.6.0",
         "fastest-levenshtein": "^1.0.16",
         "fs-minipass": "^3.0.3",
-        "glob": "^10.3.10",
+        "glob": "^10.4.5",
         "graceful-fs": "^4.2.11",
-        "hosted-git-info": "^7.0.1",
-        "ini": "^4.1.1",
-        "init-package-json": "^6.0.0",
-        "is-cidr": "^5.0.3",
-        "json-parse-even-better-errors": "^3.0.1",
-        "libnpmaccess": "^8.0.1",
-        "libnpmdiff": "^6.0.3",
-        "libnpmexec": "^7.0.4",
-        "libnpmfund": "^5.0.1",
-        "libnpmhook": "^10.0.0",
-        "libnpmorg": "^6.0.1",
-        "libnpmpack": "^6.0.3",
-        "libnpmpublish": "^9.0.2",
-        "libnpmsearch": "^7.0.0",
-        "libnpmteam": "^6.0.0",
-        "libnpmversion": "^5.0.1",
-        "make-fetch-happen": "^13.0.0",
-        "minimatch": "^9.0.3",
-        "minipass": "^7.0.4",
+        "hosted-git-info": "^8.0.2",
+        "ini": "^5.0.0",
+        "init-package-json": "^7.0.2",
+        "is-cidr": "^5.1.0",
+        "json-parse-even-better-errors": "^4.0.0",
+        "libnpmaccess": "^9.0.0",
+        "libnpmdiff": "^7.0.0",
+        "libnpmexec": "^9.0.0",
+        "libnpmfund": "^6.0.0",
+        "libnpmhook": "^11.0.0",
+        "libnpmorg": "^7.0.0",
+        "libnpmpack": "^8.0.0",
+        "libnpmpublish": "^10.0.1",
+        "libnpmsearch": "^8.0.0",
+        "libnpmteam": "^7.0.0",
+        "libnpmversion": "^7.0.0",
+        "make-fetch-happen": "^14.0.3",
+        "minimatch": "^9.0.5",
+        "minipass": "^7.1.1",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^10.0.1",
-        "nopt": "^7.2.0",
-        "normalize-package-data": "^6.0.0",
-        "npm-audit-report": "^5.0.0",
-        "npm-install-checks": "^6.3.0",
-        "npm-package-arg": "^11.0.1",
-        "npm-pick-manifest": "^9.0.0",
-        "npm-profile": "^9.0.0",
-        "npm-registry-fetch": "^16.1.0",
-        "npm-user-validate": "^2.0.0",
-        "npmlog": "^7.0.1",
+        "node-gyp": "^11.0.0",
+        "nopt": "^8.0.0",
+        "normalize-package-data": "^7.0.0",
+        "npm-audit-report": "^6.0.0",
+        "npm-install-checks": "^7.1.1",
+        "npm-package-arg": "^12.0.0",
+        "npm-pick-manifest": "^10.0.0",
+        "npm-profile": "^11.0.1",
+        "npm-registry-fetch": "^18.0.2",
+        "npm-user-validate": "^3.0.0",
         "p-map": "^4.0.0",
-        "pacote": "^17.0.5",
-        "parse-conflict-json": "^3.0.1",
-        "proc-log": "^3.0.0",
+        "pacote": "^19.0.1",
+        "parse-conflict-json": "^4.0.0",
+        "proc-log": "^5.0.0",
         "qrcode-terminal": "^0.12.0",
-        "read": "^2.1.0",
-        "semver": "^7.5.4",
-        "spdx-expression-parse": "^3.0.1",
-        "ssri": "^10.0.5",
-        "strip-ansi": "^7.1.0",
+        "read": "^4.0.0",
+        "semver": "^7.6.3",
+        "spdx-expression-parse": "^4.0.0",
+        "ssri": "^12.0.0",
         "supports-color": "^9.4.0",
-        "tar": "^6.2.0",
+        "tar": "^6.2.1",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^1.3.0",
         "treeverse": "^3.0.0",
-        "validate-npm-package-name": "^5.0.0",
-        "which": "^4.0.0",
-        "write-file-atomic": "^5.0.1"
+        "validate-npm-package-name": "^6.0.0",
+        "which": "^5.0.0",
+        "write-file-atomic": "^6.0.0"
       },
       "bin": {
         "npm": "bin/npm-cli.js",
@@ -3385,16 +3392,6 @@
       },
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/@colors/colors": {
-      "version": "1.5.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.1.90"
       }
     },
     "node_modules/npm/node_modules/@isaacs/cliui": {
@@ -3412,6 +3409,18 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
@@ -3437,6 +3446,33 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/npm/node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
       "version": "1.1.0",
       "dev": true,
@@ -3444,7 +3480,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/agent": {
-      "version": "2.2.0",
+      "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3453,49 +3489,51 @@
         "http-proxy-agent": "^7.0.0",
         "https-proxy-agent": "^7.0.1",
         "lru-cache": "^10.0.1",
-        "socks-proxy-agent": "^8.0.1"
+        "socks-proxy-agent": "^8.0.3"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "7.2.2",
+      "version": "8.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/fs": "^3.1.0",
-        "@npmcli/installed-package-contents": "^2.0.2",
-        "@npmcli/map-workspaces": "^3.0.2",
-        "@npmcli/metavuln-calculator": "^7.0.0",
-        "@npmcli/name-from-folder": "^2.0.0",
-        "@npmcli/node-gyp": "^3.0.0",
-        "@npmcli/package-json": "^5.0.0",
-        "@npmcli/query": "^3.0.1",
-        "@npmcli/run-script": "^7.0.2",
-        "bin-links": "^4.0.1",
-        "cacache": "^18.0.0",
+        "@npmcli/fs": "^4.0.0",
+        "@npmcli/installed-package-contents": "^3.0.0",
+        "@npmcli/map-workspaces": "^4.0.1",
+        "@npmcli/metavuln-calculator": "^8.0.0",
+        "@npmcli/name-from-folder": "^3.0.0",
+        "@npmcli/node-gyp": "^4.0.0",
+        "@npmcli/package-json": "^6.0.1",
+        "@npmcli/query": "^4.0.0",
+        "@npmcli/redact": "^3.0.0",
+        "@npmcli/run-script": "^9.0.1",
+        "bin-links": "^5.0.0",
+        "cacache": "^19.0.1",
         "common-ancestor-path": "^1.0.1",
-        "hosted-git-info": "^7.0.1",
-        "json-parse-even-better-errors": "^3.0.0",
+        "hosted-git-info": "^8.0.0",
+        "json-parse-even-better-errors": "^4.0.0",
         "json-stringify-nice": "^1.1.4",
-        "minimatch": "^9.0.0",
-        "nopt": "^7.0.0",
-        "npm-install-checks": "^6.2.0",
-        "npm-package-arg": "^11.0.1",
-        "npm-pick-manifest": "^9.0.0",
-        "npm-registry-fetch": "^16.0.0",
-        "npmlog": "^7.0.1",
-        "pacote": "^17.0.4",
-        "parse-conflict-json": "^3.0.0",
-        "proc-log": "^3.0.0",
+        "lru-cache": "^10.2.2",
+        "minimatch": "^9.0.4",
+        "nopt": "^8.0.0",
+        "npm-install-checks": "^7.1.0",
+        "npm-package-arg": "^12.0.0",
+        "npm-pick-manifest": "^10.0.0",
+        "npm-registry-fetch": "^18.0.1",
+        "pacote": "^19.0.0",
+        "parse-conflict-json": "^4.0.0",
+        "proc-log": "^5.0.0",
+        "proggy": "^3.0.0",
         "promise-all-reject-late": "^1.0.0",
-        "promise-call-limit": "^1.0.2",
-        "read-package-json-fast": "^3.0.2",
+        "promise-call-limit": "^3.0.1",
+        "read-package-json-fast": "^4.0.0",
         "semver": "^7.3.7",
-        "ssri": "^10.0.5",
+        "ssri": "^12.0.0",
         "treeverse": "^3.0.0",
         "walk-up-path": "^3.0.1"
       },
@@ -3503,57 +3541,30 @@
         "arborist": "bin/index.js"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "8.0.3",
+      "version": "9.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/map-workspaces": "^3.0.2",
+        "@npmcli/map-workspaces": "^4.0.1",
+        "@npmcli/package-json": "^6.0.1",
         "ci-info": "^4.0.0",
-        "ini": "^4.1.0",
-        "nopt": "^7.0.0",
-        "proc-log": "^3.0.0",
-        "read-package-json-fast": "^3.0.2",
+        "ini": "^5.0.0",
+        "nopt": "^8.0.0",
+        "proc-log": "^5.0.0",
         "semver": "^7.3.5",
         "walk-up-path": "^3.0.1"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/disparity-colors": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "ansi-styles": "^4.3.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@npmcli/disparity-colors/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/fs": {
-      "version": "3.1.0",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -3561,148 +3572,191 @@
         "semver": "^7.3.5"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/git": {
-      "version": "5.0.3",
+      "version": "6.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/promise-spawn": "^7.0.0",
+        "@npmcli/promise-spawn": "^8.0.0",
+        "ini": "^5.0.0",
         "lru-cache": "^10.0.1",
-        "npm-pick-manifest": "^9.0.0",
-        "proc-log": "^3.0.0",
+        "npm-pick-manifest": "^10.0.0",
+        "proc-log": "^5.0.0",
         "promise-inflight": "^1.0.1",
         "promise-retry": "^2.0.1",
         "semver": "^7.3.5",
-        "which": "^4.0.0"
+        "which": "^5.0.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
-      "version": "2.0.2",
+      "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-bundled": "^3.0.0",
-        "npm-normalize-package-bin": "^3.0.0"
+        "npm-bundled": "^4.0.0",
+        "npm-normalize-package-bin": "^4.0.0"
       },
       "bin": {
-        "installed-package-contents": "lib/index.js"
+        "installed-package-contents": "bin/index.js"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
-      "version": "3.0.4",
+      "version": "4.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/name-from-folder": "^2.0.0",
+        "@npmcli/name-from-folder": "^3.0.0",
+        "@npmcli/package-json": "^6.0.0",
         "glob": "^10.2.2",
-        "minimatch": "^9.0.0",
-        "read-package-json-fast": "^3.0.0"
+        "minimatch": "^9.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
-      "version": "7.0.0",
+      "version": "8.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "cacache": "^18.0.0",
-        "json-parse-even-better-errors": "^3.0.0",
-        "pacote": "^17.0.0",
+        "cacache": "^19.0.0",
+        "json-parse-even-better-errors": "^4.0.0",
+        "pacote": "^20.0.0",
+        "proc-log": "^5.0.0",
         "semver": "^7.3.5"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/npm/node_modules/@npmcli/name-from-folder": {
-      "version": "2.0.0",
+    "node_modules/npm/node_modules/@npmcli/metavuln-calculator/node_modules/pacote": {
+      "version": "20.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "dependencies": {
+        "@npmcli/git": "^6.0.0",
+        "@npmcli/installed-package-contents": "^3.0.0",
+        "@npmcli/package-json": "^6.0.0",
+        "@npmcli/promise-spawn": "^8.0.0",
+        "@npmcli/run-script": "^9.0.0",
+        "cacache": "^19.0.0",
+        "fs-minipass": "^3.0.0",
+        "minipass": "^7.0.2",
+        "npm-package-arg": "^12.0.0",
+        "npm-packlist": "^9.0.0",
+        "npm-pick-manifest": "^10.0.0",
+        "npm-registry-fetch": "^18.0.0",
+        "proc-log": "^5.0.0",
+        "promise-retry": "^2.0.1",
+        "sigstore": "^3.0.0",
+        "ssri": "^12.0.0",
+        "tar": "^6.1.11"
+      },
+      "bin": {
+        "pacote": "bin/index.js"
+      },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/npm/node_modules/@npmcli/node-gyp": {
+    "node_modules/npm/node_modules/@npmcli/name-from-folder": {
       "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/node-gyp": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/package-json": {
-      "version": "5.0.0",
+      "version": "6.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/git": "^5.0.0",
+        "@npmcli/git": "^6.0.0",
         "glob": "^10.2.2",
-        "hosted-git-info": "^7.0.0",
-        "json-parse-even-better-errors": "^3.0.0",
-        "normalize-package-data": "^6.0.0",
-        "proc-log": "^3.0.0",
+        "hosted-git-info": "^8.0.0",
+        "json-parse-even-better-errors": "^4.0.0",
+        "normalize-package-data": "^7.0.0",
+        "proc-log": "^5.0.0",
         "semver": "^7.5.3"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/promise-spawn": {
-      "version": "7.0.0",
+      "version": "8.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "which": "^4.0.0"
+        "which": "^5.0.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/query": {
-      "version": "3.0.1",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "postcss-selector-parser": "^6.0.10"
+        "postcss-selector-parser": "^6.1.2"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/@npmcli/redact": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
-      "version": "7.0.2",
+      "version": "9.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/node-gyp": "^3.0.0",
-        "@npmcli/promise-spawn": "^7.0.0",
-        "node-gyp": "^10.0.0",
-        "read-package-json-fast": "^3.0.0",
-        "which": "^4.0.0"
+        "@npmcli/node-gyp": "^4.0.0",
+        "@npmcli/package-json": "^6.0.0",
+        "@npmcli/promise-spawn": "^8.0.0",
+        "node-gyp": "^11.0.0",
+        "proc-log": "^5.0.0",
+        "which": "^5.0.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/@pkgjs/parseargs": {
@@ -3715,52 +3769,26 @@
         "node": ">=14"
       }
     },
-    "node_modules/npm/node_modules/@sigstore/bundle": {
-      "version": "2.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sigstore/protobuf-specs": "^0.2.1"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-      "version": "0.2.1",
+      "version": "0.3.2",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/@sigstore/sign": {
-      "version": "2.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@sigstore/bundle": "^2.1.0",
-        "@sigstore/protobuf-specs": "^0.2.1",
-        "make-fetch-happen": "^13.0.0"
-      },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/@sigstore/tuf": {
-      "version": "2.2.0",
+      "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/protobuf-specs": "^0.2.1",
-        "tuf-js": "^2.1.0"
+        "@sigstore/protobuf-specs": "^0.3.2",
+        "tuf-js": "^3.0.1"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/@tufjs/canonical-json": {
@@ -3772,42 +3800,17 @@
         "node": "^16.14.0 || >=18.0.0"
       }
     },
-    "node_modules/npm/node_modules/@tufjs/models": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "@tufjs/canonical-json": "2.0.0",
-        "minimatch": "^9.0.3"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
     "node_modules/npm/node_modules/abbrev": {
-      "version": "2.0.0",
+      "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/abort-controller": {
-      "version": "3.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/agent-base": {
-      "version": "7.1.0",
+      "version": "7.1.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -3832,15 +3835,12 @@
       }
     },
     "node_modules/npm/node_modules/ansi-regex": {
-      "version": "6.0.1",
+      "version": "5.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+        "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/ansi-styles": {
@@ -3867,67 +3867,38 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/are-we-there-yet": {
-      "version": "4.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^4.1.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
     "node_modules/npm/node_modules/balanced-match": {
       "version": "1.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/base64-js": {
-      "version": "1.5.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/npm/node_modules/bin-links": {
-      "version": "4.0.3",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "cmd-shim": "^6.0.0",
-        "npm-normalize-package-bin": "^3.0.0",
-        "read-cmd-shim": "^4.0.0",
-        "write-file-atomic": "^5.0.0"
+        "cmd-shim": "^7.0.0",
+        "npm-normalize-package-bin": "^4.0.0",
+        "proc-log": "^5.0.0",
+        "read-cmd-shim": "^5.0.0",
+        "write-file-atomic": "^6.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/binary-extensions": {
-      "version": "2.2.0",
+      "version": "2.3.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
@@ -3939,46 +3910,13 @@
         "balanced-match": "^1.0.0"
       }
     },
-    "node_modules/npm/node_modules/buffer": {
-      "version": "6.0.3",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/npm/node_modules/builtins": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.0.0"
-      }
-    },
     "node_modules/npm/node_modules/cacache": {
-      "version": "18.0.1",
+      "version": "19.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/fs": "^3.1.0",
+        "@npmcli/fs": "^4.0.0",
         "fs-minipass": "^3.0.0",
         "glob": "^10.2.2",
         "lru-cache": "^10.0.1",
@@ -3986,13 +3924,88 @@
         "minipass-collect": "^2.0.1",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
-        "p-map": "^4.0.0",
-        "ssri": "^10.0.0",
-        "tar": "^6.1.11",
-        "unique-filename": "^3.0.0"
+        "p-map": "^7.0.2",
+        "ssri": "^12.0.0",
+        "tar": "^7.4.3",
+        "unique-filename": "^4.0.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/cacache/node_modules/chownr": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/npm/node_modules/cacache/node_modules/minizlib": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.0.4",
+        "rimraf": "^5.0.5"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/npm/node_modules/cacache/node_modules/mkdirp": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/cacache/node_modules/p-map": {
+      "version": "7.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npm/node_modules/cacache/node_modules/tar": {
+      "version": "7.4.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.0.1",
+        "mkdirp": "^3.0.1",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/npm/node_modules/cacache/node_modules/yallist": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/npm/node_modules/chalk": {
@@ -4017,7 +4030,7 @@
       }
     },
     "node_modules/npm/node_modules/ci-info": {
-      "version": "4.0.0",
+      "version": "4.1.0",
       "dev": true,
       "funding": [
         {
@@ -4032,7 +4045,7 @@
       }
     },
     "node_modules/npm/node_modules/cidr-regex": {
-      "version": "4.0.3",
+      "version": "4.1.1",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -4065,58 +4078,13 @@
         "node": ">= 10"
       }
     },
-    "node_modules/npm/node_modules/cli-columns/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/cli-columns/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/cli-table3": {
-      "version": "0.6.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "string-width": "^4.2.0"
-      },
-      "engines": {
-        "node": "10.* || >= 12.*"
-      },
-      "optionalDependencies": {
-        "@colors/colors": "1.5.0"
-      }
-    },
-    "node_modules/npm/node_modules/clone": {
-      "version": "1.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/npm/node_modules/cmd-shim": {
-      "version": "6.0.2",
+      "version": "7.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/color-convert": {
@@ -4137,63 +4105,14 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/color-support": {
-      "version": "1.1.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "bin": {
-        "color-support": "bin.js"
-      }
-    },
-    "node_modules/npm/node_modules/columnify": {
-      "version": "1.6.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "strip-ansi": "^6.0.1",
-        "wcwidth": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/columnify/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/columnify/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/npm/node_modules/common-ancestor-path": {
       "version": "1.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
-    "node_modules/npm/node_modules/console-control-strings": {
-      "version": "1.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
     "node_modules/npm/node_modules/cross-spawn": {
-      "version": "7.0.3",
+      "version": "7.0.6",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -4234,12 +4153,12 @@
       }
     },
     "node_modules/npm/node_modules/debug": {
-      "version": "4.3.4",
+      "version": "4.3.7",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -4250,32 +4169,8 @@
         }
       }
     },
-    "node_modules/npm/node_modules/debug/node_modules/ms": {
-      "version": "2.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/defaults": {
-      "version": "1.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "clone": "^1.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm/node_modules/delegates": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/npm/node_modules/diff": {
-      "version": "5.1.0",
+      "version": "5.2.0",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -4320,24 +4215,6 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/npm/node_modules/events": {
-      "version": "3.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
     "node_modules/npm/node_modules/exponential-backoff": {
       "version": "3.1.1",
       "dev": true,
@@ -4354,7 +4231,7 @@
       }
     },
     "node_modules/npm/node_modules/foreground-child": {
-      "version": "3.1.1",
+      "version": "3.3.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4381,72 +4258,21 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/npm/node_modules/function-bind": {
-      "version": "1.1.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/npm/node_modules/gauge": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^1.0.3 || ^2.0.0",
-        "color-support": "^1.1.3",
-        "console-control-strings": "^1.1.0",
-        "has-unicode": "^2.0.1",
-        "signal-exit": "^4.0.1",
-        "string-width": "^4.2.3",
-        "strip-ansi": "^6.0.1",
-        "wide-align": "^1.1.5"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/gauge/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/gauge/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/npm/node_modules/glob": {
-      "version": "10.3.10",
+      "version": "10.4.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
-        "jackspeak": "^2.3.5",
-        "minimatch": "^9.0.1",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-        "path-scurry": "^1.10.1"
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
       },
       "bin": {
         "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -4458,26 +4284,8 @@
       "inBundle": true,
       "license": "ISC"
     },
-    "node_modules/npm/node_modules/has-unicode": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/hasown": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "function-bind": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      }
-    },
     "node_modules/npm/node_modules/hosted-git-info": {
-      "version": "7.0.1",
+      "version": "8.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4485,7 +4293,7 @@
         "lru-cache": "^10.0.1"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/http-cache-semantics": {
@@ -4495,7 +4303,7 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/npm/node_modules/http-proxy-agent": {
-      "version": "7.0.0",
+      "version": "7.0.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -4508,7 +4316,7 @@
       }
     },
     "node_modules/npm/node_modules/https-proxy-agent": {
-      "version": "7.0.2",
+      "version": "7.0.5",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -4533,28 +4341,8 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/npm/node_modules/ieee754": {
-      "version": "1.2.1",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "inBundle": true,
-      "license": "BSD-3-Clause"
-    },
     "node_modules/npm/node_modules/ignore-walk": {
-      "version": "6.0.4",
+      "version": "7.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4562,7 +4350,7 @@
         "minimatch": "^9.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/imurmurhash": {
@@ -4584,37 +4372,44 @@
       }
     },
     "node_modules/npm/node_modules/ini": {
-      "version": "4.1.1",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/init-package-json": {
-      "version": "6.0.0",
+      "version": "7.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-package-arg": "^11.0.0",
-        "promzard": "^1.0.0",
-        "read": "^2.0.0",
-        "read-package-json": "^7.0.0",
+        "@npmcli/package-json": "^6.0.0",
+        "npm-package-arg": "^12.0.0",
+        "promzard": "^2.0.0",
+        "read": "^4.0.0",
         "semver": "^7.3.5",
         "validate-npm-package-license": "^3.0.4",
-        "validate-npm-package-name": "^5.0.0"
+        "validate-npm-package-name": "^6.0.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/npm/node_modules/ip": {
-      "version": "2.0.0",
+    "node_modules/npm/node_modules/ip-address": {
+      "version": "9.0.5",
       "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/npm/node_modules/ip-regex": {
       "version": "5.0.0",
@@ -4629,27 +4424,15 @@
       }
     },
     "node_modules/npm/node_modules/is-cidr": {
-      "version": "5.0.3",
+      "version": "5.1.0",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "cidr-regex": "4.0.3"
+        "cidr-regex": "^4.1.1"
       },
       "engines": {
         "node": ">=14"
-      }
-    },
-    "node_modules/npm/node_modules/is-core-module": {
-      "version": "2.13.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "hasown": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/npm/node_modules/is-fullwidth-code-point": {
@@ -4661,12 +4444,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/npm/node_modules/is-lambda": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/npm/node_modules/isexe": {
       "version": "2.0.0",
       "dev": true,
@@ -4674,15 +4451,12 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/jackspeak": {
-      "version": "2.3.6",
+      "version": "3.4.3",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
-      },
-      "engines": {
-        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -4691,13 +4465,19 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/npm/node_modules/jsbn": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
-      "version": "3.0.1",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/json-stringify-nice": {
@@ -4731,206 +4511,210 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/libnpmaccess": {
-      "version": "8.0.2",
+      "version": "9.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-package-arg": "^11.0.1",
-        "npm-registry-fetch": "^16.0.0"
+        "npm-package-arg": "^12.0.0",
+        "npm-registry-fetch": "^18.0.1"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "6.0.4",
+      "version": "7.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^7.2.1",
-        "@npmcli/disparity-colors": "^3.0.0",
-        "@npmcli/installed-package-contents": "^2.0.2",
-        "binary-extensions": "^2.2.0",
+        "@npmcli/arborist": "^8.0.0",
+        "@npmcli/installed-package-contents": "^3.0.0",
+        "binary-extensions": "^2.3.0",
         "diff": "^5.1.0",
-        "minimatch": "^9.0.0",
-        "npm-package-arg": "^11.0.1",
-        "pacote": "^17.0.4",
-        "tar": "^6.2.0"
+        "minimatch": "^9.0.4",
+        "npm-package-arg": "^12.0.0",
+        "pacote": "^19.0.0",
+        "tar": "^6.2.1"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "7.0.5",
+      "version": "9.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^7.2.1",
-        "@npmcli/run-script": "^7.0.2",
+        "@npmcli/arborist": "^8.0.0",
+        "@npmcli/run-script": "^9.0.1",
         "ci-info": "^4.0.0",
-        "npm-package-arg": "^11.0.1",
-        "npmlog": "^7.0.1",
-        "pacote": "^17.0.4",
-        "proc-log": "^3.0.0",
-        "read": "^2.0.0",
-        "read-package-json-fast": "^3.0.2",
+        "npm-package-arg": "^12.0.0",
+        "pacote": "^19.0.0",
+        "proc-log": "^5.0.0",
+        "read": "^4.0.0",
+        "read-package-json-fast": "^4.0.0",
         "semver": "^7.3.7",
         "walk-up-path": "^3.0.1"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "5.0.2",
+      "version": "6.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^7.2.1"
+        "@npmcli/arborist": "^8.0.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/libnpmhook": {
+      "version": "11.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "npm-registry-fetch": "^18.0.1"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmorg": {
+      "version": "7.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^2.0.0",
+        "npm-registry-fetch": "^18.0.1"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmpack": {
+      "version": "8.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/arborist": "^8.0.0",
+        "@npmcli/run-script": "^9.0.1",
+        "npm-package-arg": "^12.0.0",
+        "pacote": "^19.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/libnpmpublish": {
       "version": "10.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "aproba": "^2.0.0",
-        "npm-registry-fetch": "^16.0.0"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmorg": {
-      "version": "6.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "aproba": "^2.0.0",
-        "npm-registry-fetch": "^16.0.0"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmpack": {
-      "version": "6.0.4",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "@npmcli/arborist": "^7.2.1",
-        "@npmcli/run-script": "^7.0.2",
-        "npm-package-arg": "^11.0.1",
-        "pacote": "^17.0.4"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/libnpmpublish": {
-      "version": "9.0.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
         "ci-info": "^4.0.0",
-        "normalize-package-data": "^6.0.0",
-        "npm-package-arg": "^11.0.1",
-        "npm-registry-fetch": "^16.0.0",
-        "proc-log": "^3.0.0",
+        "normalize-package-data": "^7.0.0",
+        "npm-package-arg": "^12.0.0",
+        "npm-registry-fetch": "^18.0.1",
+        "proc-log": "^5.0.0",
         "semver": "^7.3.7",
-        "sigstore": "^2.1.0",
-        "ssri": "^10.0.5"
+        "sigstore": "^3.0.0",
+        "ssri": "^12.0.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/libnpmsearch": {
-      "version": "7.0.1",
+      "version": "8.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-registry-fetch": "^16.0.0"
+        "npm-registry-fetch": "^18.0.1"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/libnpmteam": {
-      "version": "6.0.1",
+      "version": "7.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "aproba": "^2.0.0",
-        "npm-registry-fetch": "^16.0.0"
+        "npm-registry-fetch": "^18.0.1"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/libnpmversion": {
-      "version": "5.0.2",
+      "version": "7.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/git": "^5.0.3",
-        "@npmcli/run-script": "^7.0.2",
-        "json-parse-even-better-errors": "^3.0.0",
-        "proc-log": "^3.0.0",
+        "@npmcli/git": "^6.0.1",
+        "@npmcli/run-script": "^9.0.1",
+        "json-parse-even-better-errors": "^4.0.0",
+        "proc-log": "^5.0.0",
         "semver": "^7.3.7"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "10.1.0",
+      "version": "10.4.3",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
-      "engines": {
-        "node": "14 || >=16.14"
-      }
+      "license": "ISC"
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "13.0.0",
+      "version": "14.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/agent": "^2.0.0",
-        "cacache": "^18.0.0",
+        "@npmcli/agent": "^3.0.0",
+        "cacache": "^19.0.1",
         "http-cache-semantics": "^4.1.1",
-        "is-lambda": "^1.0.1",
         "minipass": "^7.0.2",
-        "minipass-fetch": "^3.0.0",
+        "minipass-fetch": "^4.0.0",
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
-        "negotiator": "^0.6.3",
+        "negotiator": "^1.0.0",
+        "proc-log": "^5.0.0",
         "promise-retry": "^2.0.1",
-        "ssri": "^10.0.0"
+        "ssri": "^12.0.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/make-fetch-happen/node_modules/negotiator": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "9.0.3",
+      "version": "9.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4945,7 +4729,7 @@
       }
     },
     "node_modules/npm/node_modules/minipass": {
-      "version": "7.0.4",
+      "version": "7.1.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -4966,20 +4750,33 @@
       }
     },
     "node_modules/npm/node_modules/minipass-fetch": {
-      "version": "3.0.4",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "minipass": "^7.0.3",
         "minipass-sized": "^1.0.3",
-        "minizlib": "^2.1.2"
+        "minizlib": "^3.0.1"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       },
       "optionalDependencies": {
         "encoding": "^0.1.13"
+      }
+    },
+    "node_modules/npm/node_modules/minipass-fetch/node_modules/minizlib": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.0.4",
+        "rimraf": "^5.0.5"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/npm/node_modules/minipass-flush": {
@@ -4995,28 +4792,6 @@
       }
     },
     "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-json-stream": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "jsonparse": "^1.3.1",
-        "minipass": "^3.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-json-stream/node_modules/minipass": {
       "version": "3.3.6",
       "dev": true,
       "inBundle": true,
@@ -5120,25 +4895,16 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/mute-stream": {
-      "version": "1.0.0",
+      "version": "2.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/negotiator": {
-      "version": "0.6.3",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "10.0.1",
+      "version": "11.0.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5147,22 +4913,85 @@
         "exponential-backoff": "^3.1.1",
         "glob": "^10.3.10",
         "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^13.0.0",
-        "nopt": "^7.0.0",
-        "proc-log": "^3.0.0",
+        "make-fetch-happen": "^14.0.3",
+        "nopt": "^8.0.0",
+        "proc-log": "^5.0.0",
         "semver": "^7.3.5",
-        "tar": "^6.1.2",
-        "which": "^4.0.0"
+        "tar": "^7.4.3",
+        "which": "^5.0.0"
       },
       "bin": {
         "node-gyp": "bin/node-gyp.js"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/chownr": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/minizlib": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.0.4",
+        "rimraf": "^5.0.5"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/mkdirp": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/tar": {
+      "version": "7.4.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.0.1",
+        "mkdirp": "^3.0.1",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/yallist": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/npm/node_modules/nopt": {
-      "version": "7.2.0",
+      "version": "8.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5173,47 +5002,55 @@
         "nopt": "bin/nopt.js"
       },
       "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/nopt/node_modules/abbrev": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm/node_modules/normalize-package-data": {
-      "version": "6.0.0",
+      "version": "7.0.0",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "hosted-git-info": "^7.0.0",
-        "is-core-module": "^2.8.1",
+        "hosted-git-info": "^8.0.0",
         "semver": "^7.3.5",
         "validate-npm-package-license": "^3.0.4"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/npm-audit-report": {
-      "version": "5.0.0",
+      "version": "6.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/npm-bundled": {
-      "version": "3.0.0",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "npm-normalize-package-bin": "^3.0.0"
+        "npm-normalize-package-bin": "^4.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/npm-install-checks": {
-      "version": "6.3.0",
+      "version": "7.1.1",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -5221,113 +5058,112 @@
         "semver": "^7.1.1"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/npm-normalize-package-bin": {
-      "version": "3.0.1",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/npm-package-arg": {
+      "version": "12.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "hosted-git-info": "^8.0.0",
+        "proc-log": "^5.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-name": "^6.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-packlist": {
+      "version": "9.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "ignore-walk": "^7.0.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-pick-manifest": {
+      "version": "10.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "npm-install-checks": "^7.1.0",
+        "npm-normalize-package-bin": "^4.0.0",
+        "npm-package-arg": "^12.0.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-profile": {
       "version": "11.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "hosted-git-info": "^7.0.0",
-        "proc-log": "^3.0.0",
-        "semver": "^7.3.5",
-        "validate-npm-package-name": "^5.0.0"
+        "npm-registry-fetch": "^18.0.0",
+        "proc-log": "^5.0.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-packlist": {
-      "version": "8.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "ignore-walk": "^6.0.4"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-pick-manifest": {
-      "version": "9.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-install-checks": "^6.0.0",
-        "npm-normalize-package-bin": "^3.0.0",
-        "npm-package-arg": "^11.0.0",
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/npm-profile": {
-      "version": "9.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "npm-registry-fetch": "^16.0.0",
-        "proc-log": "^3.0.0"
-      },
-      "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
-      "version": "16.1.0",
+      "version": "18.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "make-fetch-happen": "^13.0.0",
+        "@npmcli/redact": "^3.0.0",
+        "jsonparse": "^1.3.1",
+        "make-fetch-happen": "^14.0.0",
         "minipass": "^7.0.2",
-        "minipass-fetch": "^3.0.0",
-        "minipass-json-stream": "^1.0.1",
-        "minizlib": "^2.1.2",
-        "npm-package-arg": "^11.0.0",
-        "proc-log": "^3.0.0"
+        "minipass-fetch": "^4.0.0",
+        "minizlib": "^3.0.1",
+        "npm-package-arg": "^12.0.0",
+        "proc-log": "^5.0.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/npm-registry-fetch/node_modules/minizlib": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.0.4",
+        "rimraf": "^5.0.5"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/npm/node_modules/npm-user-validate": {
-      "version": "2.0.0",
+      "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/npmlog": {
-      "version": "7.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "are-we-there-yet": "^4.0.0",
-        "console-control-strings": "^1.1.0",
-        "gauge": "^5.0.0",
-        "set-blocking": "^2.0.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/p-map": {
@@ -5345,50 +5181,55 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/npm/node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "BlueOak-1.0.0"
+    },
     "node_modules/npm/node_modules/pacote": {
-      "version": "17.0.5",
+      "version": "19.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/git": "^5.0.0",
-        "@npmcli/installed-package-contents": "^2.0.1",
-        "@npmcli/promise-spawn": "^7.0.0",
-        "@npmcli/run-script": "^7.0.0",
-        "cacache": "^18.0.0",
+        "@npmcli/git": "^6.0.0",
+        "@npmcli/installed-package-contents": "^3.0.0",
+        "@npmcli/package-json": "^6.0.0",
+        "@npmcli/promise-spawn": "^8.0.0",
+        "@npmcli/run-script": "^9.0.0",
+        "cacache": "^19.0.0",
         "fs-minipass": "^3.0.0",
         "minipass": "^7.0.2",
-        "npm-package-arg": "^11.0.0",
-        "npm-packlist": "^8.0.0",
-        "npm-pick-manifest": "^9.0.0",
-        "npm-registry-fetch": "^16.0.0",
-        "proc-log": "^3.0.0",
+        "npm-package-arg": "^12.0.0",
+        "npm-packlist": "^9.0.0",
+        "npm-pick-manifest": "^10.0.0",
+        "npm-registry-fetch": "^18.0.0",
+        "proc-log": "^5.0.0",
         "promise-retry": "^2.0.1",
-        "read-package-json": "^7.0.0",
-        "read-package-json-fast": "^3.0.0",
-        "sigstore": "^2.0.0",
-        "ssri": "^10.0.0",
+        "sigstore": "^3.0.0",
+        "ssri": "^12.0.0",
         "tar": "^6.1.11"
       },
       "bin": {
-        "pacote": "lib/bin.js"
+        "pacote": "bin/index.js"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/parse-conflict-json": {
-      "version": "3.0.1",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "json-parse-even-better-errors": "^3.0.0",
+        "json-parse-even-better-errors": "^4.0.0",
         "just-diff": "^6.0.0",
         "just-diff-apply": "^5.2.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/path-key": {
@@ -5401,23 +5242,23 @@
       }
     },
     "node_modules/npm/node_modules/path-scurry": {
-      "version": "1.10.1",
+      "version": "1.11.1",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "lru-cache": "^9.1.1 || ^10.0.0",
+        "lru-cache": "^10.2.0",
         "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
+        "node": ">=16 || 14 >=14.18"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
-      "version": "6.0.13",
+      "version": "6.1.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -5430,21 +5271,21 @@
       }
     },
     "node_modules/npm/node_modules/proc-log": {
+      "version": "5.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/proggy": {
       "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/process": {
-      "version": "0.11.10",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/promise-all-reject-late": {
@@ -5457,7 +5298,7 @@
       }
     },
     "node_modules/npm/node_modules/promise-call-limit": {
-      "version": "1.0.2",
+      "version": "3.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5485,15 +5326,15 @@
       }
     },
     "node_modules/npm/node_modules/promzard": {
-      "version": "1.0.0",
+      "version": "2.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "read": "^2.0.0"
+        "read": "^4.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/qrcode-terminal": {
@@ -5505,68 +5346,37 @@
       }
     },
     "node_modules/npm/node_modules/read": {
-      "version": "2.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "mute-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/read-cmd-shim": {
       "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "dependencies": {
+        "mute-stream": "^2.0.0"
+      },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/npm/node_modules/read-package-json": {
-      "version": "7.0.0",
+    "node_modules/npm/node_modules/read-cmd-shim": {
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "dependencies": {
-        "glob": "^10.2.2",
-        "json-parse-even-better-errors": "^3.0.0",
-        "normalize-package-data": "^6.0.0",
-        "npm-normalize-package-bin": "^3.0.0"
-      },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/read-package-json-fast": {
-      "version": "3.0.2",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "json-parse-even-better-errors": "^3.0.0",
-        "npm-normalize-package-bin": "^3.0.0"
+        "json-parse-even-better-errors": "^4.0.0",
+        "npm-normalize-package-bin": "^4.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/readable-stream": {
-      "version": "4.4.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/retry": {
@@ -5578,25 +5388,20 @@
         "node": ">= 4"
       }
     },
-    "node_modules/npm/node_modules/safe-buffer": {
-      "version": "5.2.1",
+    "node_modules/npm/node_modules/rimraf": {
+      "version": "5.0.10",
       "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
       "inBundle": true,
-      "license": "MIT"
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.3.7"
+      },
+      "bin": {
+        "rimraf": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/npm/node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -5606,37 +5411,16 @@
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.5.4",
+      "version": "7.6.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/npm/node_modules/semver/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/npm/node_modules/set-blocking": {
-      "version": "2.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
     },
     "node_modules/npm/node_modules/shebang-command": {
       "version": "2.0.0",
@@ -5672,18 +5456,72 @@
       }
     },
     "node_modules/npm/node_modules/sigstore": {
-      "version": "2.1.0",
+      "version": "3.0.0",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@sigstore/bundle": "^2.1.0",
-        "@sigstore/protobuf-specs": "^0.2.1",
-        "@sigstore/sign": "^2.1.0",
-        "@sigstore/tuf": "^2.1.0"
+        "@sigstore/bundle": "^3.0.0",
+        "@sigstore/core": "^2.0.0",
+        "@sigstore/protobuf-specs": "^0.3.2",
+        "@sigstore/sign": "^3.0.0",
+        "@sigstore/tuf": "^3.0.0",
+        "@sigstore/verify": "^2.0.0"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/bundle": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/protobuf-specs": "^0.3.2"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/core": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/sign": {
+      "version": "3.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/bundle": "^3.0.0",
+        "@sigstore/core": "^2.0.0",
+        "@sigstore/protobuf-specs": "^0.3.2",
+        "make-fetch-happen": "^14.0.1",
+        "proc-log": "^5.0.0",
+        "promise-retry": "^2.0.1"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/verify": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@sigstore/bundle": "^3.0.0",
+        "@sigstore/core": "^2.0.0",
+        "@sigstore/protobuf-specs": "^0.3.2"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/smart-buffer": {
@@ -5697,28 +5535,28 @@
       }
     },
     "node_modules/npm/node_modules/socks": {
-      "version": "2.7.1",
+      "version": "2.8.3",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ip": "^2.0.0",
+        "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
       },
       "engines": {
-        "node": ">= 10.13.0",
+        "node": ">= 10.0.0",
         "npm": ">= 3.0.0"
       }
     },
     "node_modules/npm/node_modules/socks-proxy-agent": {
-      "version": "8.0.2",
+      "version": "8.0.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "agent-base": "^7.0.2",
+        "agent-base": "^7.1.1",
         "debug": "^4.3.4",
-        "socks": "^2.7.1"
+        "socks": "^2.8.3"
       },
       "engines": {
         "node": ">= 14"
@@ -5734,13 +5572,7 @@
         "spdx-license-ids": "^3.0.0"
       }
     },
-    "node_modules/npm/node_modules/spdx-exceptions": {
-      "version": "2.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "CC-BY-3.0"
-    },
-    "node_modules/npm/node_modules/spdx-expression-parse": {
+    "node_modules/npm/node_modules/spdx-correct/node_modules/spdx-expression-parse": {
       "version": "3.0.1",
       "dev": true,
       "inBundle": true,
@@ -5750,14 +5582,36 @@
         "spdx-license-ids": "^3.0.0"
       }
     },
+    "node_modules/npm/node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/npm/node_modules/spdx-expression-parse": {
+      "version": "4.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
     "node_modules/npm/node_modules/spdx-license-ids": {
-      "version": "3.0.16",
+      "version": "3.0.20",
       "dev": true,
       "inBundle": true,
       "license": "CC0-1.0"
     },
+    "node_modules/npm/node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/npm/node_modules/ssri": {
-      "version": "10.0.5",
+      "version": "12.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5765,16 +5619,7 @@
         "minipass": "^7.0.3"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm/node_modules/string_decoder": {
-      "version": "1.3.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/string-width": {
@@ -5806,61 +5651,16 @@
         "node": ">=8"
       }
     },
-    "node_modules/npm/node_modules/string-width-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/string-width-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/string-width/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/string-width/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/npm/node_modules/strip-ansi": {
-      "version": "7.1.0",
+      "version": "6.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-regex": "^6.0.1"
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+        "node": ">=8"
       }
     },
     "node_modules/npm/node_modules/strip-ansi-cjs": {
@@ -5872,15 +5672,6 @@
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -5898,7 +5689,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "6.2.0",
+      "version": "6.2.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5969,33 +5760,46 @@
       }
     },
     "node_modules/npm/node_modules/tuf-js": {
-      "version": "2.1.0",
+      "version": "3.0.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "@tufjs/models": "2.0.0",
-        "debug": "^4.3.4",
-        "make-fetch-happen": "^13.0.0"
+        "@tufjs/models": "3.0.1",
+        "debug": "^4.3.6",
+        "make-fetch-happen": "^14.0.1"
       },
       "engines": {
-        "node": "^16.14.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/npm/node_modules/tuf-js/node_modules/@tufjs/models": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tufjs/canonical-json": "2.0.0",
+        "minimatch": "^9.0.5"
+      },
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/unique-filename": {
-      "version": "3.0.0",
+      "version": "4.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "unique-slug": "^4.0.0"
+        "unique-slug": "^5.0.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/unique-slug": {
-      "version": "4.0.0",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6003,7 +5807,7 @@
         "imurmurhash": "^0.1.4"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/util-deprecate": {
@@ -6022,16 +5826,23 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "node_modules/npm/node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
     "node_modules/npm/node_modules/validate-npm-package-name": {
-      "version": "5.0.0",
+      "version": "6.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
-      "dependencies": {
-        "builtins": "^5.0.0"
-      },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/walk-up-path": {
@@ -6040,17 +5851,8 @@
       "inBundle": true,
       "license": "ISC"
     },
-    "node_modules/npm/node_modules/wcwidth": {
-      "version": "1.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "defaults": "^1.0.3"
-      }
-    },
     "node_modules/npm/node_modules/which": {
-      "version": "4.0.0",
+      "version": "5.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6061,7 +5863,7 @@
         "node-which": "bin/which.js"
       },
       "engines": {
-        "node": "^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/which/node_modules/isexe": {
@@ -6071,15 +5873,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=16"
-      }
-    },
-    "node_modules/npm/node_modules/wide-align": {
-      "version": "1.1.5",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
     "node_modules/npm/node_modules/wrap-ansi": {
@@ -6117,15 +5910,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
       "version": "4.3.0",
       "dev": true,
@@ -6141,16 +5925,16 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
-      "version": "6.0.1",
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
@@ -6176,8 +5960,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/npm/node_modules/write-file-atomic": {
-      "version": "5.0.1",
+      "version": "6.0.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6186,7 +5985,7 @@
         "signal-exit": "^4.0.1"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": "^18.17.0 || >=20.5.0"
       }
     },
     "node_modules/npm/node_modules/yallist": {
@@ -7396,9 +7195,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
+      "integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
       "dev": true,
       "dependencies": {
         "chownr": "^1.1.1",


### PR DESCRIPTION
Apply fixes for the following:

```
braces  <3.0.3
Severity: high
Uncontrolled resource consumption in braces - https://github.com/advisories/GHSA-grv7-fg5c-xmjg
fix available via `npm audit fix`
node_modules/braces

cross-spawn  7.0.0 - 7.0.4
Severity: high
Regular Expression Denial of Service (ReDoS) in cross-spawn - https://github.com/advisories/GHSA-3xgq-45jj-v275
fix available via `npm audit fix`
node_modules/cross-spawn
node_modules/npm/node_modules/cross-spawn

ip  *
Severity: high
NPM IP package incorrectly identifies some private IP addresses as public - https://github.com/advisories/GHSA-78xj-cgh5-2h22
ip SSRF improper categorization in isPublic - https://github.com/advisories/GHSA-2p57-rm9w-gvfp
fix available via `npm audit fix`
node_modules/npm/node_modules/ip
  socks  1.0.0 - 2.7.1
  Depends on vulnerable versions of ip
  node_modules/npm/node_modules/socks

micromatch  <4.0.8
Severity: moderate
Regular Expression Denial of Service (ReDoS) in micromatch - https://github.com/advisories/GHSA-952p-6rrq-rcjv
fix available via `npm audit fix`
node_modules/micromatch

tar  <6.2.1
Severity: moderate
Denial of service while parsing a tar file due to lack of folders count validation - https://github.com/advisories/GHSA-f5x3-32g6-xq36
fix available via `npm audit fix`
node_modules/npm/node_modules/tar
  npm  <=9.9.3 || 10.0.0-pre.0 - 10.5.0
  Depends on vulnerable versions of tar
  node_modules/npm

tar-fs  2.0.0 - 2.1.1
Severity: high
tar-fs Vulnerable to Link Following and Path Traversal via Extracting a Crafted tar File - https://github.com/advisories/GHSA-pq67-2wwv-3xjx
fix available via `npm audit fix`
node_modules/tar-fs
```